### PR TITLE
Refactor board to use bitboards and castling bitmasks

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+pub type Bitboard = u64;
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Piece {
     Pawn,
@@ -37,4 +39,12 @@ pub fn rank_to_index(rank: char) -> usize {
 
 pub fn format_square(sq: Square) -> String {
     format!("{}{}", (sq.1 as u8 + b'a') as char, sq.0 + 1)
+}
+
+pub fn square_index(sq: Square) -> usize {
+    sq.0 * 8 + sq.1
+}
+
+pub fn bitboard_for_square(sq: Square) -> Bitboard {
+    1u64 << square_index(sq)
 }


### PR DESCRIPTION
## Summary
- replace the square matrix with bitboard-based storage and bitmask castling rights
- update move execution, hashing, and generators to operate on the new helpers
- expose shared bitboard utilities for square indexing

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e3d2c9f8e48321a89eaa0acb9928af

## Summary by Sourcery

Refactor board representation to use bitboards and bitmask-based castling rights and update all related operations accordingly

New Features:
- Add Bitboard alias and bitboard_for_square and square_index helper functions

Enhancements:
- Replace 8×8 piece matrix with per-piece and occupancy bitboards
- Encode castling rights as a u8 bitmask with helper functions for querying and updating
- Revise board initialization, FEN parsing, and Zobrist hashing to iterate over bitboards
- Update move execution, unmake logic, and move generation to operate on bitboard-based APIs
- Enhance board display to format castling rights as a string